### PR TITLE
support RHEL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
 - name: nickhammond.logrotate | Install logrotate
-  apt:
-    pkg: logrotate
-    state: present
+  action: "{{ansible_pkg_mgr}} pkg=logrotate state=present"
+
 
 - name: nickhammond.logrotate | Setup logrotate.d scripts
   template: 


### PR DESCRIPTION
use `ansible_pkg_mgr` variable to use available package manager and thus support RHEL
