### PR TITLE
ansible_managed comment in generated configs

### DIFF
--- a/templates/logrotate.d.j2
+++ b/templates/logrotate.d.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 "{{ item.path }}" {
   {% if item.options is defined -%}
   {% for option in item.options -%}


### PR DESCRIPTION
Hi! I thought it would be nice to add a note to the generated configs like this: 

```
# This file was generated by Ansible for staging-test5

/var/log/mongod/mongod.log {
    compress
    copytruncate
    daily
    dateext
    rotate 7
    size 10M
}
```
