### PR TITLE
Adding the ability to change logrotate schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ logrotate_scripts:
       - copytruncate
 ```
 
+**logrotate_cron**: A cron map that, when defined, will change how often logrotate is executed.
+
+* Time unit keys map directly to the cron module.
+
+```
+logrotate_cron:
+  minute: "*/5"
+```
+
 Dependencies
 ------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,3 +8,15 @@
     dest: /etc/logrotate.d/{{ item.name }}
   with_items: logrotate_scripts
   when: logrotate_scripts is defined
+
+- name: nickhammond.logrotate | Change logrotate execution schedule
+  cron:
+    name: "Run logrotate on a non-default schedule"
+    job: "/usr/sbin/logrotate /etc/logrotate.conf"
+    month: "{{ logrotate_cron.month|default('*') }}"
+    day: "{{ logrotate_cron.day|default('*') }}"
+    hour: "{{ logrotate_cron.hour|default('*') }}"
+    minute: "{{ logrotate_cron.minute|default('*') }}"
+    weekday: "{{ logrotate_cron.weekday|default('*') }}"
+    state: present
+  when: logrotate_cron is defined

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -16,3 +16,7 @@
           path: /var/log/nginx/scripts.log
           scripts:
             postrotate: "echo test"
+
+    - role: ansible-logrotate
+      logrotate_cron:
+        minute: "*/5"


### PR DESCRIPTION
For chatty or high frequency applications, running logrotate more often than hourly is mandatory.
