### PR TITLE
Set the correct file mode for the config file.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,5 +6,6 @@
   template:
     src: logrotate.d.j2
     dest: /etc/logrotate.d/{{ item.name }}
+    mode: u=rw,g=r,o=r
   with_items: logrotate_scripts
   when: logrotate_scripts is defined


### PR DESCRIPTION
Without this the mode ends up being u=rw,g=rw,o=r, and logrotate will complain "Ignoring <config> because of bad file mode."
