### PR TITLE
Clarify the example playbook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,23 @@ None
 Example Playbook
 -------------------------
 
-Setting up logrotate for additional Nginx logs, with postrotate script.
+Setting up logrotate for additional Nginx logs, with postrotate script (assuming this role is located in `roles/logrotate`).
 
 ```
-logrotate_scripts:
-  - name: nginx
-    path: /var/log/nginx/*.log
-    options:
-      - weekly
-      - size 25M
-      - rotate 7
-      - missingok
-      - compress
-      - delaycompress
-      - copytruncate
-    scripts:
-      postrotate: "[ -s /run/nginx.pid ] && kill -USR1 `cat /run/nginx.pid`"
-
+- role: logrotate
+  logrotate_scripts:
+    - name: nginx
+      path: /var/log/nginx/*.log
+      options:
+        - weekly
+        - size 25M
+        - rotate 7
+        - missingok
+        - compress
+        - delaycompress
+        - copytruncate
+      scripts:
+        postrotate: "[ -s /run/nginx.pid ] && kill -USR1 `cat /run/nginx.pid`"
 ```
 
 License


### PR DESCRIPTION
Hi,

I've modified the nginx example in the README to include full `role` declaration, which I think makes it much clearer to how to use it. 
