### PR TITLE
fix: remove extra double quotes in template

### DIFF
--- a/templates/logrotate.d.j2
+++ b/templates/logrotate.d.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-"{{ item.path }}" {
+{{ item.path }} {
   {% if item.options is defined -%}
   {% for option in item.options -%}
   {{ option }}


### PR DESCRIPTION
Forcing double quotes in the template cause troubles in case someone want to
define multiples paths to file (example below).

According the man, double quotes around the filename allows logrotate to rotate
logs with spaces in the name.

``` yaml
logrotate_scripts:
  - name: syslog
    path: /var/log/cron /var/log/maillog /var/log/messages /var/log/secure /var/log/spooler
    options:
      - compress
      - delaycompress
      - missingok
      - notifempty
      - rotate 4
      - sharedscripts
      - weekly
    scripts:
      postrotate: "/bin/kill -HUP $(cat /var/run/rsyslogd.pid) 2> /dev/null"
    - name: httpd
    path: /var/log/httpd/*log /var/log/httpd/*/*log
    options:
      - compress
      - delaycompress
      - missingok
      - notifempty
      - rotate 15
      - sharedscripts
      - daily
    scripts:
      postrotate: "/bin/systemctl reload httpd.service &>/dev/null || true"
```

This should work if someone need to rotate multiple files including path with
spaces:

``` yaml
logrotate_scripts:
    - name: httpd
    path: '/var/log/httpd/*log "/var/log/httpd/subdirectory with space/*log"'
    options:
      - compress
      - delaycompress
      - missingok
      - notifempty
      - rotate 15
      - sharedscripts
      - daily
    scripts:
      postrotate: "/bin/systemctl reload httpd.service &>/dev/null || true"
```
