### PR TITLE
Syntax improvements + consistency

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,13 @@
 ---
 - name: nickhammond.logrotate | Install logrotate
-  action: "{{ansible_pkg_mgr}} pkg=logrotate state=present"
-  when: logrotate_scripts is defined and len(logrotate_scripts) > 0
+  package:
+    name: logrotate
+    state: present
+  when: logrotate_scripts is defined and logrotate_scripts|length > 0
 
 - name: nickhammond.logrotate | Setup logrotate.d scripts
   template:
     src: logrotate.d.j2
     dest: "{{ logrotate_conf_dir }}{{ item.name }}"
-  with_items: logrotate_scripts
+  with_items: "{{ logrotate_scripts }}"
   when: logrotate_scripts is defined


### PR DESCRIPTION
Use `package` module instead of the dynamic `action`. Also changes to consistency YML formatting and fixes an Ansible 2.0.1 deprecation warning about "bare" variables.
