### PR TITLE
Add CentOS/EL version 7 support on Ansible Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,9 @@ galaxy_info:
     - lucid
     - precise
     - trusty
+   - name: EL
+     versions:
+     - 7
   categories:
   - system
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,9 +10,9 @@ galaxy_info:
     - lucid
     - precise
     - trusty
-   - name: EL
-     versions:
-     - 7
+  - name: EL
+    versions:
+    - 7
   categories:
   - system
 dependencies: []


### PR DESCRIPTION
Hello, 

Following tests on my infrastructure, your package work on CENTOS 7.
Meta file updated.

Signed-off-by: Loïc Chabert loic.chabert@voxity.fr
