### PR TITLE
allow multiple paths per script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ None
 
 * name - The name of the script that goes into /etc/logrotate.d/
 * path - Path to point logrotate to for the log rotation
+* paths - A list of paths to point logrotate to for the log rotation.
 * options - List of directives for logrotate, view the logrotate man page for specifics
 * scripts - Dict of scripts for logrotate (see Example below)
 
@@ -22,6 +23,21 @@ None
 logrotate_scripts:
   - name: rails
     path: "/srv/current/log/*.log"
+    options:
+      - weekly
+      - size 25M
+      - missingok
+      - compress
+      - delaycompress
+      - copytruncate
+```
+
+```
+logrotate_scripts:
+  - name: rails
+    paths:
+        - "/srv/current/scare.log"
+        - "/srv/current/hide.log"
     options:
       - weekly
       - size 25M

--- a/templates/logrotate.d.j2
+++ b/templates/logrotate.d.j2
@@ -1,6 +1,13 @@
 # {{ ansible_managed }}
 
-"{{ item.path }}" {
+{% if 'path' in item %}
+"{{ item.path }}"
+{% elif 'paths' in item %}
+{% for path in item.paths %}
+"{{ path }}"
+{% endfor %}
+{% endif %}
+{
   {% if item.options is defined -%}
   {% for option in item.options -%}
   {{ option }}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,6 +13,11 @@
         scripts:
           postrotate: "echo test"
 
+      - name: multiple-paths
+        paths:
+          - /var/log/nginx/options.log
+          - /var/log/nginx/scripts.log
+
   roles:
     - ansible-logrotate
 


### PR DESCRIPTION
added a new `paths` variable that can be used in each script instead of `path` to allow people to specify multiple paths in 1 script without breaking backwards compatibility.