### PR TITLE
Adds `logrotate_replace_old_configurations` to override existing configurations that are not managed by this role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 ---
+
+dist: trusty
+
 language: python
 
 python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,27 @@
 ---
 language: python
+
 python: "2.7"
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq python-apt python-pycurl
+
 install:
   - pip install ansible
+
+before_script:
+  - export TEST_OVERRIDE_CONF_DIR=${TRAVIS_BUILD_DIR}/override-configuration
+  - mkdir "${TEST_OVERRIDE_CONF_DIR}"
+  - printf "/log\n/other\n{\n\tdaily\n}" > ${TEST_OVERRIDE_CONF_DIR}/existing-1
+  - printf "/other\n{\n\t/log\n}" > ${TEST_OVERRIDE_CONF_DIR}/existing-2
+
 script:
   - "printf '[defaults]\nroles_path = ../' > ansible.cfg"
   - ansible-playbook -i tests/inventory --syntax-check tests/test.yml
   - ansible-playbook -i tests/inventory --connection=local --become -vvvv tests/test.yml
+  - echo "$(printf '/other\n{\n\tdaily\n}' | md5sum | cut -d ' ' -f 1) ${TEST_OVERRIDE_CONF_DIR}/existing-1" | md5sum -c -
+  - echo "$(printf '/other\n{\n\t/log\n}' | md5sum | cut -d ' ' -f 1) ${TEST_OVERRIDE_CONF_DIR}/existing-2" | md5sum -c -
+
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -11,25 +11,22 @@ None
 
 ## Role Variables
 
-**logrotate_scripts**: A list of logrotate scripts and the directives to use for the rotation.
+* **logrotate_conf_dir**: String defining the location of the directory containing the logrotate configuration files.
 
-* name - The name of the script that goes into /etc/logrotate.d/
-* path - Path to point logrotate to for the log rotation
-* options - List of directives for logrotate, view the logrotate man page for specifics
-* scripts - Dict of scripts for logrotate (see Example below)
+* **logrotate_scripts**: A list of logrotate scripts and the directives to use for the rotation.
+    * name - The name of the script that goes into /etc/logrotate.d/
+    * path - Path to point logrotate to for the log rotation
+    * options - List of directives for logrotate, view the logrotate man page for specifics
+    * scripts - Dict of scripts for logrotate (see Example below)
+    
+* **logrotate_replace_old_configurations**: Boolean defining whether to remove conflicting path configurations defined 
+in configuration files not managed by this role.
+<br><br>
+E.g. if you define a configuration for managing `/var/log/kern.log`, you may find that this has done before in 
+`/etc/logrotate.d/rsyslog` (along with configurations for a number of other log paths). Setting this variable to `true` 
+in this case will remove the old configuration from `/var/log/kern.log`, whilst leaving the other configurations in 
+`/var/log/rsyslog` unaltered.
 
-```
-logrotate_scripts:
-  - name: rails
-    path: "/srv/current/log/*.log"
-    options:
-      - weekly
-      - size 25M
-      - missingok
-      - compress
-      - delaycompress
-      - copytruncate
-```
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 logrotate_conf_dir: "/etc/logrotate.d/"
 logrotate_scripts: []
+
+logrotate_replace_old_configurations: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 logrotate_conf_dir: "/etc/logrotate.d/"
 logrotate_scripts: []
 
-logrotate_replace_old_configurations: true
+logrotate_replace_old_configurations: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,4 +10,27 @@
     src: logrotate.d.j2
     dest: "{{ logrotate_conf_dir }}{{ item.name }}"
   with_items: "{{ logrotate_scripts }}"
+  register: setup_configurations
   when: logrotate_scripts is defined
+
+- name: Find all log rotate configurations
+  find:
+    paths: "{{ logrotate_conf_dir }}"
+    # Not matching backups, which end in ~
+    patterns: ".*[^~]$"
+    use_regex: True
+    follow: True
+  register: all_configurations
+  when: logrotate_replace_old_configurations and logrotate_scripts is defined
+
+- name: Remove conflicting path configurations previously defined in non-Ansible managed files
+  replace:
+    path: "{{ item[0] }}"
+    # For examples of what the regex matches, see: https://regex101.com/r/l0e9eQ/5
+    regexp: '(?![^{]*})(((?<=\n\n)|^){{ item[1] }}\s{(.|\n)*?\n\s*}|((?<=\n)|^){{ item[1] }}\s)'
+    replace: ""
+    backup: yes
+  with_nested:
+    - "{{ all_configurations.files | map(attribute='path') | difference(setup_configurations.results | map(attribute='path')) }}"
+    - "{{ logrotate_scripts | map(attribute='path') | list }}"
+  when: logrotate_replace_old_configurations and logrotate_scripts is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,6 @@
     # For examples of what the regex matches, see: https://regex101.com/r/l0e9eQ/5
     regexp: '(?![^{]*})(((?<=\n\n)|^){{ item[1] }}\s{(.|\n)*?\n\s*}|((?<=\n)|^){{ item[1] }}\s)'
     replace: ""
-    backup: yes
   with_nested:
     - "{{ all_configurations.files | map(attribute='path') | difference(logrotate_scripts | map(attribute='path')) | list }}"
     - "{{ logrotate_scripts | map(attribute='path') | list }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,6 @@
     src: logrotate.d.j2
     dest: "{{ logrotate_conf_dir }}{{ item.name }}"
   with_items: "{{ logrotate_scripts }}"
-  register: setup_configurations
   when: logrotate_scripts is defined
 
 - name: Find all log rotate configurations
@@ -31,6 +30,6 @@
     replace: ""
     backup: yes
   with_nested:
-    - "{{ all_configurations.files | map(attribute='path') | difference(setup_configurations.results | map(attribute='path')) }}"
+    - "{{ all_configurations.files | map(attribute='path') | difference(logrotate_scripts | map(attribute='path')) | list }}"
     - "{{ logrotate_scripts | map(attribute='path') | list }}"
   when: logrotate_replace_old_configurations and logrotate_scripts is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
   register: all_configurations
   when: logrotate_replace_old_configurations and logrotate_scripts is defined
 
-- name: Remove conflicting path configurations previously defined in non-Ansible managed files
+- name: Remove conflicting path configurations defined in files not managed by this role
   replace:
     path: "{{ item[0] }}"
     # For examples of what the regex matches, see: https://regex101.com/r/l0e9eQ/5

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -16,3 +16,12 @@
           path: /var/log/nginx/scripts.log
           scripts:
             postrotate: "echo test"
+
+    - role: ansible-logrotate
+      logrotate_conf_dir: "{{ lookup('env', 'TEST_OVERRIDE_CONF_DIR') }}"
+      logrotate_replace_old_configurations: true
+      logrotate_scripts:
+        - name: override
+          path: /log
+          options:
+            - daily


### PR DESCRIPTION
Implements #27.

Adds setting to define whether to remove conflicting path configurations defined in configuration files not managed by this role.

E.g. if you define a configuration for managing `/var/log/kern.log`, you may find that this has done before in `/etc/logrotate.d/rsyslog` (along with configurations for a number of other log paths). Setting this new variable to `true` in this case will remove the old configuration from `/var/log/kern.log`, whilst leaving the other configurations in `/var/log/rsyslog` unaltered.