### PR TITLE
Update templates/logrotate.d.j2

### DIFF
--- a/templates/logrotate.d.j2
+++ b/templates/logrotate.d.j2
@@ -7,7 +7,7 @@
   {% endfor -%}
   {% endif %}
   {%- if item.scripts is defined -%}
-  {%- for name, script in item.scripts.iteritems() -%}
+  {%- for name, script in item.scripts.items() -%}
   {{ name }}
     {{ script }}
   endscript


### PR DESCRIPTION
* replace iteriterms() by items() to be Python3 compatible

Because iteritems() is deprecated in Python3 ( https://www.python.org/dev/peps/pep-0469/ )

