### PR TITLE
Add become to allow commands to be run as user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
     name: logrotate
     state: present
   when: logrotate_scripts is defined and logrotate_scripts|length > 0
+  become: true
 
 - name: nickhammond.logrotate | Setup logrotate.d scripts
   template:
@@ -11,3 +12,4 @@
     dest: "{{ logrotate_conf_dir }}{{ item.name }}"
   with_items: "{{ logrotate_scripts }}"
   when: logrotate_scripts is defined
+  become: true


### PR DESCRIPTION
Hey there,

This PR adds `become: true` in the commands that require root permissions to run. This is needed in the use case of running ansible when generating an AMI using Packer (it connects to the machine as **admin**, not **root**).

Any doubts feel free to shoot them :)

Cheers