### PR TITLE
Support running hourly logrotates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,5 @@
+---
+
 logrotate_conf_dir: "/etc/logrotate.d/"
 logrotate_scripts: []
+logrotate_support_hourly_rotates: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,23 @@
 ---
+
 - name: nickhammond.logrotate | Install logrotate
   package:
     name: logrotate
     state: present
   when: logrotate_scripts is defined and logrotate_scripts|length > 0
+
+- name: Check for logrotate daily cron entry
+  stat:
+    path: "{{ logrotate_cron_daily_location }}"
+  register: daily_cron_entry
+  when: logrotate_support_hourly_rotates
+
+- name: Move logrotate cron entry from daily to hourly
+  command: "mv '{{ logrotate_cron_daily_location }}' '{{ logrotate_cron_hourly_location }}'"
+  args:
+    creates: "{{ logrotate_cron_hourly_location }}"
+    removes: "{{ logrotate_cron_daily_location }}"
+  when: logrotate_support_hourly_rotates and daily_cron_entry.stat.exists
 
 - name: nickhammond.logrotate | Setup logrotate.d scripts
   template:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+logrotate_cron_hourly_location: /etc/cron.hourly/logrotate
+logrotate_cron_daily_location: /etc/cron.daily/logrotate


### PR DESCRIPTION
This role allows hourly rotates to be configured but the setup does not actually support them because the logrotate cron is only ran daily. To support the hourly logging feature, [the manual notes](http://manpages.ubuntu.com/manpages/xenial/man8/logrotate.8.html):
```
hourly  Log files are rotated every hour. Note that usually logrotate is
        configured  to  be  run  by  cron daily. You have to change this
        configuration and run logrotate hourly  to  be  able  to  really
        rotate logs hourly.
```

Unlike the rejected PR https://github.com/nickhammond/ansible-logrotate/pull/7, this PR only aims to only support standard functionality provided by logrotate.